### PR TITLE
Adding "-webkit-overflow-scrolling:touch;" for smooth scrolling on iOS

### DIFF
--- a/slidebars/0.9/slidebars.css
+++ b/slidebars/0.9/slidebars.css
@@ -63,6 +63,7 @@ body {
 .sb-slidebar {
 	height: 100%;
 	overflow-y: auto; /* Enable vertical scrolling on Slidebars when needed. */
+	-webkit-overflow-scrolling: touch; /* Enable smooth scrolling on iOS devices */
 	position: fixed;
 	top: 0;
 	z-index: 0; /* Slidebars sit behind sb-site. */


### PR DESCRIPTION
The slidebar menu scroll on iOS is not smooth. Adding `-webkit-overflow-scrolling:touch;` to the `.sb-slidebar` css solves this issue. Now we have smooth scrolling on the sidebar.
