### PR TITLE
remove 3d translate upon close

### DIFF
--- a/development/slidebars.js
+++ b/development/slidebars.js
@@ -227,6 +227,12 @@
 					$('html').removeClass('sb-active sb-active-left sb-active-right'); // Remove active classes.
 					if ($left) $left.removeClass('sb-active');
 					if ($right) $right.removeClass('sb-active');
+
+					//keeping a 3d transform on the sb-site div will decrease scrolling frames per second in Chrome. 
+					if (animation === 'translate') {
+						$site.css('transform', 'none');
+					}
+
 					if (link) window.location = link; // If a link has been passed to the function, go to it.
 				}, 400);
 			}


### PR DESCRIPTION
Hi, great work with this plugin. I was looking for a decent hardware accelerated option just like this! 

I discovered that if you keep a 3d transform on the main #sb-site div, scrolling performance will be poor in Chrome. (More noticeable on a retina macbook pro) The FPS was dropping well below 30 with this transform. I think it also becomes a lot worse if there are numerous pictures on the page. 

I added a small change to the close function and it just sets the transform to 'none' after closing the sidebar. This restores scrolling performance. 
