### PR TITLE
Fix issue for elements with fixed position

### DIFF
--- a/development/slidebars.js
+++ b/development/slidebars.js
@@ -161,7 +161,7 @@
 			
 			// Apply animation
 			if (animation === 'translate') {
-				selector.css('transform', 'translate(' + amount + ')');
+				selector.css('transform', amount === '0px' ? 'none' : 'translate(' + amount + ')');
 
 			} else if (animation === 'side') {		
 				if (amount[0] === '-') amount = amount.substr(1); // Remove the '-' from the passed amount for side animations.


### PR DESCRIPTION
**Original post :** 
http://stackoverflow.com/q/23915033/1238019

**Description :**
When an element has `position: fixed`, applying `transform: translate(0px)` to its parent make its position to be overriden. 

**Example :**
(Extract from the SO post)
- Open [this fiddle](http://jsfiddle.net/NCyL4/)
- Scroll : the <kbd>Menu</kbd> button stay in place (because its `position: fixed`)
- Click on <kbd>Menu</kbd> (button disappears)
- Close the opened menu (button reappears)
- Scroll : **the <kbd>Menu</kbd> lost its fixed position**

**Fix :**
Change `transform: translate(0px)` by `transform: none` to avoid the override.
