### PR TITLE
Attempted fix for $.slidebars breakage (issue 135)

### DIFF
--- a/development/slidebars.js
+++ b/development/slidebars.js
@@ -266,7 +266,7 @@
 		// ---------
 		// 007 - API
 		
-		this.slidebars = {
+		var slidebars = {
 			open: open, // Maps user variable name to the open method.
 			close: close, // Maps user variable name to the close method.
 			toggle: toggle, // Maps user variable name to the toggle method.


### PR DESCRIPTION
I'm not sure how the API is supposed to work. I just do

```
$.slidebars(siteClose: false)
```

in my code.

And with the original code, after this call, $.slidebars now refers to that object, not to the original $.slidebars function.

Maybe this fix does what you intend?