### PR TITLE
Remove z-index for main container.

### DIFF
--- a/dist/0.10.3/slidebars.css
+++ b/dist/0.10.3/slidebars.css
@@ -60,7 +60,6 @@ html.sb-scroll-lock.sb-active:not(.sb-static) {
 	width: 100%;
 	min-height: 100vh;
 	position: relative;
-	z-index: 1; /* Site sits above Slidebars */
 	background-color: #ffffff; /* Default background colour, overwrite this with your own css. I suggest moving your html or body background styling here. Making this transparent will allow the Slidebars beneath to be visible. */
 }
 
@@ -83,7 +82,7 @@ html.sb-scroll-lock.sb-active:not(.sb-static) {
 	overflow-y: auto; /* Enable vertical scrolling on Slidebars when needed. */
 	position: fixed;
 	top: 0;
-	z-index: 0; /* Slidebars sit behind sb-site. */
+	z-index: -1; /* Slidebars sit behind sb-site. */
 	display: none; /* Initially hide the Slidebars. Changed from visibility to display to allow -webkit-overflow-scrolling. */
 	background-color: #222222; /* Default Slidebars background colour, overwrite this with your own css. */
 }


### PR DESCRIPTION
I removed the z-index for the main container and changed the z-index of the slidebar to -1.

We had a problem with a modal of bootstrap.
The z-index of the main container destorys the z-index of the modal and make it unusable.