### PR TITLE
Fix CSS for mobile browsers and various html/body targeting libraries

### DIFF
--- a/dist/slidebars.css
+++ b/dist/slidebars.css
@@ -20,10 +20,15 @@ html, body, [canvas=container], [off-canvas] {
 	        box-sizing: border-box;
 }
 
+html {
+	overflow-y: auto;
+}
+body {
+	overflow-y: hidden;
+}
 html, body {
 	width: 100%;
-	height: 100%;
-	overflow: hidden;
+	overflow-x: hidden;
 }
 
 /**
@@ -36,8 +41,6 @@ html, body {
 
 [canvas=container] {
 	width: 100%;
-	height: 100%;
-	overflow-y: auto;
 	position: relative;
 	background-color: white; /* Basic background color, overwrite this in your own css. */
 	-webkit-overflow-scrolling: touch; /* Enables momentum scrolling on iOS devices, may be removed by setting to 'auto' in your own CSS. */

--- a/dist/slidebars.css
+++ b/dist/slidebars.css
@@ -21,9 +21,10 @@ html, body, [canvas=container], [off-canvas] {
 }
 
 html {
-	overflow-y: auto;
+	height: 100%;
 }
 body {
+	min-height: 100%;
 	overflow-y: hidden;
 }
 html, body {


### PR DESCRIPTION
Fixes: #251 
Related: #292

Todo
- [ ] Check animations (shift and reveal don't work correctly for top and bottom because `z-index: 0;`)
- [ ] Check other options (example: disable site scrolling is not working with this fix when hovering over the sidebar)
