### PR TITLE
Add AMD/RequireJS and CommonJS

### DIFF
--- a/dev/slidebars.js
+++ b/dev/slidebars.js
@@ -468,3 +468,14 @@ var slidebars = function () {
 
 	$( window ).on( 'resize', this.css.bind( this ) );
 };
+
+// AMD / RequireJS
+if (typeof define !== 'undefined' && define.amd) {
+	define([], function () {
+		return slidebars;
+	});
+}
+// CommonJS
+else if (typeof module !== 'undefined' && module.exports) {
+	module.exports = slidebars;
+}


### PR DESCRIPTION
This PR add support for AMD/RequireJS and CommonJS.
Now we can use this script with npm, webpack,... : 

``` javascript
var slidebars = require('slidebars');
var controller = new slidebars();
```

Fix the issue #256 and partially the #122 without break the actual code
