### PR TITLE
added license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"name": "slidebars",
 	"version": "2.0.2",
+        "license": "MIT",
 	"dependencies": {
 		"jquery": ">=1.8"
 	},


### PR DESCRIPTION
license needed if package is included via npm and the github app "dependencyci.com" is used